### PR TITLE
setup ci & image build-push GHA wkflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,10 +1,6 @@
 name: Build Docker image
 
-on:
-  push:
-    branches: [ master, ]
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
 
 jobs:
   prepare:
@@ -12,27 +8,57 @@ jobs:
     outputs:
       FULL_IMAGE_TAG: ${{ steps.tag.outputs.tag }}
     steps:
-      - name: Set Tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Image Tag
         id: tag
-        env:
-          version_pattern: "tags\\/v[0-9]+\\.[0-9]+\\.[0-9]+"
         run: |
-          export CI_COMMIT_SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-8)
-          echo $CI_COMMIT_SHORT_SHA;
-          echo ${GITHUB_REF##*/};
-          echo $version_pattern;
-          if [[ ${GITHUB_REF} =~ $version_pattern ]]; then
-            echo "::set-output name=tag::${GITHUB_REF##*/}"
-          elif [ ${GITHUB_REF##*/} = "master" ]; then
-            echo "::set-output name=tag::stg-$CI_COMMIT_SHORT_SHA"
-          else
-            echo "::set-output name=tag::$CI_COMMIT_SHORT_SHA"
-          fi
+          export GIT_TAG=$(git describe --abbrev=7 --always --tags)
+          echo "::set-output name=tag::${GIT_TAG}"
 
   build-image:
     runs-on: ubuntu-latest
     needs: prepare
+    if: github.ref != 'refs/heads/master' && github.event_name != 'release'
+    steps:
+      - name: Echo tag
+        id: echotag
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
+        run: |
+          echo "Building an image with the following tag:"
+          echo $IMAGE_TAG
+          echo "Based off the following commit:"
+          echo $GITHUB_SHA
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        id: configure-aws-creds
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build Image Only
+        id: build
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: pastebin
+          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+      - name: Logut of Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
 
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Echo tag
         id: echotag
@@ -46,12 +72,10 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         id: configure-aws-creds
-        env:
-          AWS_REGION: us-west-2
         with:
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: us-west-2
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -59,19 +83,50 @@ jobs:
         id: build-push
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ctms-api
+          ECR_REPOSITORY: pastebin
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
-          printf '{\n    "commit": "%s",\n    "version": "%s",\n    "image_tag": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
-            "$GITHUB_SHA" \
-            "$GITHUB_REF" \
-            "$IMAGE_TAG" \
-            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker image tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY
+      - name: Logut of Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+  promote-image:
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: github.event_name == 'release' 
+    steps:
+      - name: Echo tag
+        id: echotag
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
+        run: |
+          echo "Building an image with the following tag:"
+          echo $IMAGE_TAG
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        id: configure-aws-creds
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and push to ECR
+        id: pull-tag-push
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: pastebin
+          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
+        run: |
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       - name: Logut of Amazon ECR
         if: always()
-        run: |
-          docker logout ${{ steps.login-ecr.outputs.registry }}
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -32,28 +32,15 @@ jobs:
           echo $GITHUB_SHA
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        id: configure-aws-creds
-        with:
-          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
       - name: Build Image Only
         id: build
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ci-run
           ECR_REPOSITORY: pastebin
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-      - name: Logut of Amazon ECR
-        if: always()
-        run: docker logout ${{ steps.login-ecr.outputs.registry }}
 
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -24,5 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Run Django tests (via Docker-Compose)
         run: make test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,11 +22,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
Jira ticket: https://mozilla-hub.atlassian.net/browse/SE-1992

What this PR does:
* takes the upstream bartTC/dpaste repo & cherry picks mozafrank's changes onto it to replicate the code available in mozilla-it/pastebin & mozafrank/dpaste on the latest dpaste
* updates some of the docker-compose & python setup to have a functional docker image & local spin up via dc
* adds GitHub actions that intend to:
  * all pushes: run CI (django tests via tox & docker-compose, some code scan thing that came from upstream)
  * all pushes: build docker image only as CI as well, tagging image with git describe --tags output as well as last commit (but not pushing to ecr)
  * commits to master: build & push to ECR the docker image with git describe --tags output & full last commit as docker image tags
  * github releases created: pull docker image tagged with that last commit, retag with release tag, & push to ecr

Why this PR:
* want to use a dpaste codebase that is updated & update-able with upstream work
* want to keep customizations that mozafrank did
* want to build & push a docker image to mozilla-manage repositories for later deployment