### PR TITLE
add additional get_base_url conditional to react to envvar

### DIFF
--- a/dpaste/apps.py
+++ b/dpaste/apps.py
@@ -634,8 +634,8 @@ class dpasteAppConfig(AppConfig):
             site = get_current_site(request)
             if site:
                 return f"https://{site.domain}"
-        elif os.getenv("DPASTE_BASE_URL"):
-            domain = os.getenv("DPASTE_BASE_URL")
+        elif os.getenv("DPASTE_BASE_DOMAIN"):
+            domain = os.getenv("DPASTE_BASE_DOMAIN")
             return f"https://{domain}"
         return "https://paste.mozilla.org"
 

--- a/dpaste/apps.py
+++ b/dpaste/apps.py
@@ -1,3 +1,5 @@
+import os
+
 from django.apps import AppConfig, apps
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -632,7 +634,10 @@ class dpasteAppConfig(AppConfig):
             site = get_current_site(request)
             if site:
                 return f"https://{site.domain}"
-        return "https://dpaste-base-url.example.org"
+        elif os.getenv("DPASTE_BASE_URL"):
+            domain = os.getenv("DPASTE_BASE_URL")
+            return f"https://{domain}"
+        return "https://paste.mozilla.org"
 
     @property
     def extra_template_context(self):


### PR DESCRIPTION
Bugzilla ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=1721350

What this PR does:
* adds additional conditional to look for DPASTE_BASE_URL envvar when setting get_base_url output (used for API responses) as we don't use django sites framework atm
* sets default to return "https://paste.mozilla.org" when that get_base_url function can't find anything else to use

Some context:
* this was repaired by mozafrank at some point in the original pastebin Docker iamge by simply changing the returned value of get_base_url (see dpaste/apps.py around line 640 or see the unused fork of mozafrank's fork here https://github.com/mozilla-it/pastebin-old/blob/c267c7c96d9508d4713fb833b144a425a7bc1509/dpaste/apps.py#L599) to hardcoded "paste.mozilla.org", but this change isn't reflected in his original dpaste forked code repo (see https://github.com/mozafrank/dpaste/blob/3be4bd13075ace2b4b9530172162b1af35bbd0d2/dpaste/apps.py#L599) so was missed in the new image update
* adding the envvar instead of just hardcoding so we can test in stage as well
 * identifies use case of pastebin in a programmatic fashion (via mach) by firefox software engineers
